### PR TITLE
perf(ssr): improve ssrRenderSlot performance

### DIFF
--- a/packages/server-renderer/src/helpers/ssrRenderSlot.ts
+++ b/packages/server-renderer/src/helpers/ssrRenderSlot.ts
@@ -87,11 +87,11 @@ export function ssrRenderSlotInner(
   }
 }
 
+const commentTestRE = /^<!--.*-->$/s
 const commentRE = /<!--[^]*?-->/gm
 function isComment(item: SSRBufferItem) {
-  return (
-    typeof item === 'string' &&
-    commentRE.test(item) &&
-    !item.replace(commentRE, '').trim()
-  )
+  if (typeof item !== 'string' || !commentTestRE.test(item)) return false
+  // if item is '<!---->' or '<!--[-->' or '<!--]-->', return true directly
+  if (item.length <= 8) return true
+  return !item.replace(commentRE, '').trim()
 }


### PR DESCRIPTION
This PR replaces `isComment` function in `ssrRenderSlot` with a faster version (upto 10x faster, see: https://jsbench.me/o5l45knpk2/1)

Old `isComment`: 8029029.23 ops/s (89.1% slower)
New `isComment`: 73631038.71 ops/s